### PR TITLE
Added version command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,10 +13,17 @@ import (
 
 var (
 	cfgFile string
+  version string = "0.0.9"
 	rootCmd = &cobra.Command{
 		Use:   "ghost",
 		Short: fmt.Sprintf("\n%v Ghost is an experimental CLI that intelligently scaffolds a GitHub Action workflow based on your local application stack and natural language, using OpenAI.", emoji.Ghost),
 	}
+  versionCmd = &cobra.Command{
+    Use:   "version",
+    Run:   func(cmd *cobra.Command, args []string) {
+      fmt.Printf("Ghost Version: %v", version)
+    },
+  }
 )
 
 func Execute() error {
@@ -31,6 +38,7 @@ func init() {
 
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true
 	rootCmd.AddCommand(runCmd, configCmd)
+  rootCmd.AddCommand(versionCmd)
 }
 
 func InitConfig() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,9 +33,6 @@ func Execute() error {
 func init() {
 	cobra.OnInitialize(InitConfig)
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cobra.yaml)")
-	rootCmd.PersistentFlags().Bool("viper", true, "use Viper for configuration")
-
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true
 	rootCmd.AddCommand(runCmd, configCmd)
   rootCmd.AddCommand(versionCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,17 +13,17 @@ import (
 
 var (
 	cfgFile string
-  version string = "0.0.9"
+	Version string
 	rootCmd = &cobra.Command{
 		Use:   "ghost",
 		Short: fmt.Sprintf("\n%v Ghost is an experimental CLI that intelligently scaffolds a GitHub Action workflow based on your local application stack and natural language, using OpenAI.", emoji.Ghost),
 	}
-  versionCmd = &cobra.Command{
-    Use:   "version",
-    Run:   func(cmd *cobra.Command, args []string) {
-      fmt.Printf("Ghost Version: %v", version)
-    },
-  }
+	versionCmd = &cobra.Command{
+		Use: "version",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("Ghost Version: %v", Version)
+		},
+	}
 )
 
 func Execute() error {
@@ -35,7 +35,7 @@ func init() {
 
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true
 	rootCmd.AddCommand(runCmd, configCmd)
-  rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(versionCmd)
 }
 
 func InitConfig() {
@@ -52,7 +52,6 @@ func InitConfig() {
 		viper.SetConfigName(configName)
 		viper.SetDefault("enable_gpt_4", "false")
 		configPath := filepath.Join(configHome, configName+"."+configType)
-
 
 		if _, err := os.Stat(configPath); err == nil {
 			viper.AutomaticEnv()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ var (
 	}
 	versionCmd = &cobra.Command{
 		Use: "version",
+		Short: "Prints the Ghost version"
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("Ghost Version: %v", Version)
 		},

--- a/main.go
+++ b/main.go
@@ -4,7 +4,12 @@ import (
 	"github.com/savannahostrowski/ghost/cmd"
 )
 
+var (
+	version = "dev"
+)
+
 func main() {
+	cmd.Version = version
 	if err := cmd.Execute(); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Added `ghost version` sub-command to the tool via the `root.go` file.

Currently set to `0.0.9` as per the latest release, this will need to be updated in the `root.go` file for the next release (currently on line 16).

When running `ghost version` the output will be:
```
$ ghost version
Ghost Version: 0.0.9
```

The output can be modified in the `fmt.Printf` command (line 24).