### PR TITLE
Removed config & viper flags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,9 +26,6 @@ func Execute() error {
 func init() {
 	cobra.OnInitialize(InitConfig)
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cobra.yaml)")
-	rootCmd.PersistentFlags().Bool("viper", true, "use Viper for configuration")
-
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true
 	rootCmd.AddCommand(runCmd, configCmd)
 }


### PR DESCRIPTION
Removed the three lines from `root.go` to remove the `--viper` and `--config` flags.

This PR resolves #9 