### PR TITLE
feat: make AI provider base URL configurable via env var

### DIFF
--- a/aiClient.ts
+++ b/aiClient.ts
@@ -1,0 +1,8 @@
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+  baseURL: process.env.OPENAI_BASE_URL ?? "https://api.openai.com/v1",
+});
+
+export default client;


### PR DESCRIPTION
## What

Makes the AI provider base URL configurable via an environment variable
(`OPENAI_BASE_URL`) so the project can switch endpoints without code changes.

## Why

Hard-coding a provider URL makes it harder to test against staging endpoints,
run local models, or route to an alternative provider during an outage.
Reading the URL from an env var is a zero-risk, backward-compatible change —
**the default remains your current provider**.

## How

```python
# Before
client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))

# After
client = OpenAI(
    api_key=os.getenv("OPENAI_API_KEY"),
    base_url=os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1"),
)
```

No existing behaviour changes when `OPENAI_BASE_URL` is not set.
